### PR TITLE
feat: add artist focus page — dbt models + FastAPI endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,8 +253,14 @@ export-activities-list: ## Export activities list only (no details)
 export-garmin: ## Export Garmin data (activities) - 1x/day
 	uv run python -m src.connectors.exporter.all --scope garmin $(if $(BUCKET),--bucket $(BUCKET),)
 
-export-spotify: ## Export Spotify data (homepage + music) - 6x/day
+export-spotify: ## Export Spotify data (homepage + music + artist focus) - 6x/day
 	uv run python -m src.connectors.exporter.all --scope spotify $(if $(BUCKET),--bucket $(BUCKET),)
+
+export-artist-focus: ## Export artist focus profiles to GCS (usage: make export-artist-focus BUCKET=my-bucket)
+	uv run python -m src.connectors.exporter.artist_focus $(if $(BUCKET),--bucket $(BUCKET),)
+
+export-artist-focus-dry: ## Preview artist focus JSON export (dry-run)
+	uv run python -m src.connectors.exporter.artist_focus --dry-run
 
 # ============================================
 # API

--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 # api/main.py
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from api.routers import music, homepage, activities
+from api.routers import music, homepage, activities, artist_focus
 
 app = FastAPI(
     title="ELA DataPlatform API",
@@ -22,6 +22,7 @@ app.add_middleware(
 app.include_router(music.router, prefix="/api/music", tags=["music"])
 app.include_router(homepage.router, prefix="/api/homepage", tags=["homepage"])
 app.include_router(activities.router, prefix="/api/activities", tags=["activities"])
+app.include_router(artist_focus.router, prefix="/api/artist-focus", tags=["artist-focus"])
 
 
 @app.get("/")
@@ -44,6 +45,14 @@ async def root():
             "homepage_top_tracks": "/api/homepage/top-tracks",
             "activities_recent": "/api/activities/recent",
             "activities_list": "/api/activities/list",
+            "artist_focus_list": "/api/artist-focus/artists",
+            "artist_focus_profile": "/api/artist-focus/{artist_id}",
+            "artist_focus_overview": "/api/artist-focus/{artist_id}/overview",
+            "artist_focus_tracks": "/api/artist-focus/{artist_id}/tracks",
+            "artist_focus_albums": "/api/artist-focus/{artist_id}/albums",
+            "artist_focus_calendar": "/api/artist-focus/{artist_id}/calendar",
+            "artist_focus_heatmap": "/api/artist-focus/{artist_id}/heatmap",
+            "artist_focus_evolution": "/api/artist-focus/{artist_id}/evolution",
         },
     }
 

--- a/api/models/artist_focus.py
+++ b/api/models/artist_focus.py
@@ -1,0 +1,104 @@
+# api/models/artist_focus.py
+from pydantic import BaseModel
+from typing import Optional, List, Any
+
+
+class ArtistFocusOverview(BaseModel):
+    artist_id: str
+    artist_name: str
+    artist_url: Optional[str] = None
+    image_url: Optional[str] = None
+    image_url_medium: Optional[str] = None
+    genres: Optional[Any] = None
+    spotify_popularity: Optional[int] = None
+    follower_count: Optional[int] = None
+    total_plays: int
+    total_duration: str
+    total_duration_ms: int
+    unique_tracks: int
+    unique_albums: int
+    first_heard: str
+    last_heard: str
+    days_with_listens: int
+    days_since_discovery: int
+    consistency_score: float
+    avg_plays_per_active_day: float
+
+
+class ArtistFocusTrack(BaseModel):
+    artist_id: str
+    track_rank: int
+    track_id: str
+    track_name: str
+    album_name: Optional[str] = None
+    album_image_url: Optional[str] = None
+    track_url: Optional[str] = None
+    play_count: int
+    total_duration: str
+    total_duration_ms: int
+    first_played_at: str
+    last_played_at: str
+    pct_of_artist_time: float
+
+
+class ArtistFocusAlbum(BaseModel):
+    artist_id: str
+    album_id: str
+    album_name: str
+    album_image_url: Optional[str] = None
+    album_url: Optional[str] = None
+    album_type: Optional[str] = None
+    release_date: Optional[str] = None
+    total_tracks: int
+    tracks_heard: int
+    total_plays: int
+    total_duration: str
+    total_duration_ms: int
+    first_played_at: str
+    last_played_at: str
+    completion_rate: float
+    listen_depth: str
+    artist_names: Optional[str] = None
+
+
+class ArtistFocusCalendarDay(BaseModel):
+    artist_id: str
+    listen_date: str
+    play_count: int
+    total_duration_ms: int
+    total_duration: str
+
+
+class ArtistFocusHeatmapCell(BaseModel):
+    artist_id: str
+    hour_of_day: int
+    day_of_week: int
+    day_name: str
+    play_count: int
+    total_duration_ms: int
+
+
+class ArtistFocusMonthly(BaseModel):
+    artist_id: str
+    year_month: str
+    play_count: int
+    unique_tracks: int
+    total_duration_ms: int
+    total_duration: str
+
+
+class ArtistSummary(BaseModel):
+    artist_id: str
+    artist_name: str
+    image_url: Optional[str] = None
+    total_plays: int
+    total_duration: str
+
+
+class ArtistFocusProfile(BaseModel):
+    overview: ArtistFocusOverview
+    top_tracks: List[ArtistFocusTrack]
+    albums: List[ArtistFocusAlbum]
+    calendar: List[ArtistFocusCalendarDay]
+    heatmap: List[ArtistFocusHeatmapCell]
+    evolution: List[ArtistFocusMonthly]

--- a/api/models/artist_focus.py
+++ b/api/models/artist_focus.py
@@ -23,6 +23,7 @@ class ArtistFocusOverview(BaseModel):
     days_since_discovery: int
     consistency_score: float
     avg_plays_per_active_day: float
+    current_streak: int
 
 
 class ArtistFocusTrack(BaseModel):

--- a/api/routers/artist_focus.py
+++ b/api/routers/artist_focus.py
@@ -1,0 +1,244 @@
+# api/routers/artist_focus.py
+from fastapi import APIRouter, HTTPException, Query
+from typing import List, Optional
+import asyncio
+from api.models.artist_focus import (
+    ArtistSummary,
+    ArtistFocusOverview,
+    ArtistFocusTrack,
+    ArtistFocusAlbum,
+    ArtistFocusCalendarDay,
+    ArtistFocusHeatmapCell,
+    ArtistFocusMonthly,
+    ArtistFocusProfile,
+)
+from api.database import get_bq_client
+from api.config import PROJECT_ID, DATASET
+
+router = APIRouter()
+
+TABLE_OVERVIEW = f"`{PROJECT_ID}.{DATASET}.pct_focus_artist__overview`"
+TABLE_TOP_TRACKS = f"`{PROJECT_ID}.{DATASET}.pct_focus_artist__top_tracks`"
+TABLE_ALBUMS = f"`{PROJECT_ID}.{DATASET}.pct_focus_artist__albums`"
+TABLE_CALENDAR = f"`{PROJECT_ID}.{DATASET}.pct_focus_artist__listening_calendar`"
+TABLE_HEATMAP = f"`{PROJECT_ID}.{DATASET}.pct_focus_artist__listening_heatmap`"
+TABLE_EVOLUTION = f"`{PROJECT_ID}.{DATASET}.pct_focus_artist__evolution`"
+
+
+@router.get("/artists", response_model=List[ArtistSummary])
+async def list_artists(
+    search: Optional[str] = Query(None, description="Filter by artist name (partial match)"),
+    limit: int = Query(50, ge=1, le=200, description="Max results"),
+):
+    """Liste tous les artistes avec leurs stats globales (pour recherche / autocomplete)"""
+    where = ""
+    if search:
+        where = f"WHERE LOWER(artist_name) LIKE LOWER('%{search}%')"
+
+    query = f"""
+        SELECT
+            artist_id,
+            artist_name,
+            image_url,
+            total_plays,
+            total_duration
+        FROM {TABLE_OVERVIEW}
+        {where}
+        ORDER BY total_plays DESC
+        LIMIT {limit}
+    """
+    try:
+        bq_client = get_bq_client()
+        results = bq_client.query(query).result()
+        return [dict(row) for row in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching artists: {str(e)}")
+
+
+@router.get("/{artist_id}/overview", response_model=ArtistFocusOverview)
+async def get_artist_overview(artist_id: str):
+    """Carte d'identité + métriques globales d'un artiste"""
+    query = f"""
+        SELECT *
+        FROM {TABLE_OVERVIEW}
+        WHERE artist_id = '{artist_id}'
+        LIMIT 1
+    """
+    try:
+        bq_client = get_bq_client()
+        results = list(bq_client.query(query).result())
+        if not results:
+            raise HTTPException(status_code=404, detail=f"Artist '{artist_id}' not found")
+        return dict(results[0])
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching overview: {str(e)}")
+
+
+@router.get("/{artist_id}/tracks", response_model=List[ArtistFocusTrack])
+async def get_artist_top_tracks(artist_id: str):
+    """Top 20 titres de l'artiste classés par nombre d'écoutes"""
+    query = f"""
+        SELECT *
+        FROM {TABLE_TOP_TRACKS}
+        WHERE artist_id = '{artist_id}'
+        ORDER BY track_rank ASC
+    """
+    try:
+        bq_client = get_bq_client()
+        results = bq_client.query(query).result()
+        return [dict(row) for row in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching tracks: {str(e)}")
+
+
+@router.get("/{artist_id}/albums", response_model=List[ArtistFocusAlbum])
+async def get_artist_albums(artist_id: str):
+    """Albums de l'artiste avec taux de complétion et profondeur d'écoute"""
+    query = f"""
+        SELECT *
+        FROM {TABLE_ALBUMS}
+        WHERE artist_id = '{artist_id}'
+        ORDER BY total_duration_ms DESC
+    """
+    try:
+        bq_client = get_bq_client()
+        results = bq_client.query(query).result()
+        return [dict(row) for row in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching albums: {str(e)}")
+
+
+@router.get("/{artist_id}/calendar", response_model=List[ArtistFocusCalendarDay])
+async def get_artist_calendar(artist_id: str):
+    """Écoutes jour par jour (heatmap calendrier)"""
+    query = f"""
+        SELECT *
+        FROM {TABLE_CALENDAR}
+        WHERE artist_id = '{artist_id}'
+        ORDER BY listen_date ASC
+    """
+    try:
+        bq_client = get_bq_client()
+        results = bq_client.query(query).result()
+        return [dict(row) for row in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching calendar: {str(e)}")
+
+
+@router.get("/{artist_id}/heatmap", response_model=List[ArtistFocusHeatmapCell])
+async def get_artist_heatmap(artist_id: str):
+    """Densité d'écoute par heure x jour de la semaine"""
+    query = f"""
+        SELECT *
+        FROM {TABLE_HEATMAP}
+        WHERE artist_id = '{artist_id}'
+        ORDER BY day_of_week ASC, hour_of_day ASC
+    """
+    try:
+        bq_client = get_bq_client()
+        results = bq_client.query(query).result()
+        return [dict(row) for row in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching heatmap: {str(e)}")
+
+
+@router.get("/{artist_id}/evolution", response_model=List[ArtistFocusMonthly])
+async def get_artist_evolution(artist_id: str):
+    """Tendance mensuelle d'écoute"""
+    query = f"""
+        SELECT *
+        FROM {TABLE_EVOLUTION}
+        WHERE artist_id = '{artist_id}'
+        ORDER BY year_month ASC
+    """
+    try:
+        bq_client = get_bq_client()
+        results = bq_client.query(query).result()
+        return [dict(row) for row in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching evolution: {str(e)}")
+
+
+@router.get("/{artist_id}", response_model=ArtistFocusProfile)
+async def get_artist_profile(artist_id: str):
+    """Profil complet de l'artiste — toutes les données en un seul appel"""
+
+    async def fetch_overview():
+        query = f"""
+            SELECT * FROM {TABLE_OVERVIEW}
+            WHERE artist_id = '{artist_id}' LIMIT 1
+        """
+        bq_client = get_bq_client()
+        results = list(bq_client.query(query).result())
+        if not results:
+            raise HTTPException(status_code=404, detail=f"Artist '{artist_id}' not found")
+        return dict(results[0])
+
+    async def fetch_top_tracks():
+        query = f"""
+            SELECT * FROM {TABLE_TOP_TRACKS}
+            WHERE artist_id = '{artist_id}'
+            ORDER BY track_rank ASC
+        """
+        bq_client = get_bq_client()
+        return [dict(row) for row in bq_client.query(query).result()]
+
+    async def fetch_albums():
+        query = f"""
+            SELECT * FROM {TABLE_ALBUMS}
+            WHERE artist_id = '{artist_id}'
+            ORDER BY total_duration_ms DESC
+        """
+        bq_client = get_bq_client()
+        return [dict(row) for row in bq_client.query(query).result()]
+
+    async def fetch_calendar():
+        query = f"""
+            SELECT * FROM {TABLE_CALENDAR}
+            WHERE artist_id = '{artist_id}'
+            ORDER BY listen_date ASC
+        """
+        bq_client = get_bq_client()
+        return [dict(row) for row in bq_client.query(query).result()]
+
+    async def fetch_heatmap():
+        query = f"""
+            SELECT * FROM {TABLE_HEATMAP}
+            WHERE artist_id = '{artist_id}'
+            ORDER BY day_of_week ASC, hour_of_day ASC
+        """
+        bq_client = get_bq_client()
+        return [dict(row) for row in bq_client.query(query).result()]
+
+    async def fetch_evolution():
+        query = f"""
+            SELECT * FROM {TABLE_EVOLUTION}
+            WHERE artist_id = '{artist_id}'
+            ORDER BY year_month ASC
+        """
+        bq_client = get_bq_client()
+        return [dict(row) for row in bq_client.query(query).result()]
+
+    try:
+        overview, top_tracks, albums, calendar, heatmap, evolution = await asyncio.gather(
+            fetch_overview(),
+            fetch_top_tracks(),
+            fetch_albums(),
+            fetch_calendar(),
+            fetch_heatmap(),
+            fetch_evolution(),
+        )
+        return ArtistFocusProfile(
+            overview=overview,
+            top_tracks=top_tracks,
+            albums=albums,
+            calendar=calendar,
+            heatmap=heatmap,
+            evolution=evolution,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching artist profile: {str(e)}")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -211,11 +211,14 @@ elif [ "$MODE" = "export" ]; then
         activities)
             exec uv run python -m src.connectors.exporter.activities "${CMD_ARGS[@]}"
             ;;
+        artist_focus)
+            exec uv run python -m src.connectors.exporter.artist_focus "${CMD_ARGS[@]}"
+            ;;
         all)
             exec uv run python -m src.connectors.exporter.all "${CMD_ARGS[@]}"
             ;;
         *)
-            echo "Error: Unknown EXPORT_TYPE='$EXPORT_TYPE'. Valid values: 'homepage', 'music', 'activities', 'all'"
+            echo "Error: Unknown EXPORT_TYPE='$EXPORT_TYPE'. Valid values: 'homepage', 'music', 'activities', 'artist_focus', 'all'"
             exit 1
             ;;
     esac

--- a/src/connectors/exporter/activities.py
+++ b/src/connectors/exporter/activities.py
@@ -195,10 +195,10 @@ def export_activities(
 
     if dry_run:
         print(
-            f"    Would export activities_list.json ({len(activities_list)} activities)"
+            f"    Would export garmin/activities_list.json ({len(activities_list)} activities)"
         )
     else:
-        uri = upload_to_gcs(list_data, bucket, "activities_list.json")
+        uri = upload_to_gcs(list_data, bucket, "garmin/activities_list.json")
         uris.append(uri)
         print(f"    Done: {uri}")
 
@@ -212,10 +212,10 @@ def export_activities(
 
     if dry_run:
         print(
-            f"    Would export activities_recent.json ({len(activities_recent)} activities)"
+            f"    Would export garmin/activities_recent.json ({len(activities_recent)} activities)"
         )
     else:
-        uri = upload_to_gcs(recent_data, bucket, "activities_recent.json")
+        uri = upload_to_gcs(recent_data, bucket, "garmin/activities_recent.json")
         uris.append(uri)
         print(f"    Done: {uri}")
 
@@ -232,17 +232,17 @@ def export_activities(
             print(f"  [{i}/{len(activity_ids)}] Exporting activity {activity_id}...")
 
             if dry_run:
-                print(f"    Would export activity_{activity_id}.json")
+                print(f"    Would export garmin/activity_{activity_id}.json")
                 continue
 
             detail = fetch_activity_detail(client, activity_id)
             if detail:
                 detail["_generated_at"] = datetime.now(timezone.utc).isoformat()
-                uri = upload_to_gcs(detail, bucket, f"activity_{activity_id}.json")
+                uri = upload_to_gcs(detail, bucket, f"garmin/activity_{activity_id}.json")
                 uris.append(uri)
 
     if not dry_run:
-        print(f"\nExported {len(uris)} files to gs://{bucket}/")
+        print(f"\nExported {len(uris)} files to gs://{bucket}/garmin/")
 
     return uris
 

--- a/src/connectors/exporter/all.py
+++ b/src/connectors/exporter/all.py
@@ -66,8 +66,8 @@ def export_spotify(bucket: str, dry_run: bool = False) -> list[str]:
     uris.extend(music_uris)
 
     # Artist focus profiles
-    print("\n[3/3] Exporting artist focus profiles (top 50 + active last 24h)...")
-    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run, top_n=50)
+    print("\n[3/3] Exporting artist focus profiles...")
+    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run)
     uris.extend(artist_uris)
 
     return uris

--- a/src/connectors/exporter/all.py
+++ b/src/connectors/exporter/all.py
@@ -66,8 +66,8 @@ def export_spotify(bucket: str, dry_run: bool = False) -> list[str]:
     uris.extend(music_uris)
 
     # Artist focus profiles
-    print("\n[3/3] Exporting artist focus profiles...")
-    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run)
+    print("\n[3/3] Exporting artist focus profiles (top 50)...")
+    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run, limit=50)
     uris.extend(artist_uris)
 
     return uris

--- a/src/connectors/exporter/all.py
+++ b/src/connectors/exporter/all.py
@@ -66,8 +66,8 @@ def export_spotify(bucket: str, dry_run: bool = False) -> list[str]:
     uris.extend(music_uris)
 
     # Artist focus profiles
-    print("\n[3/3] Exporting artist focus profiles...")
-    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run)
+    print("\n[3/3] Exporting artist focus profiles (top 50 + active last 24h)...")
+    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run, top_n=50)
     uris.extend(artist_uris)
 
     return uris

--- a/src/connectors/exporter/all.py
+++ b/src/connectors/exporter/all.py
@@ -13,6 +13,7 @@ import os
 from src.connectors.exporter.homepage import export_homepage
 from src.connectors.exporter.music import export_music_classement
 from src.connectors.exporter.activities import export_activities
+from src.connectors.exporter.artist_focus import export_artist_focus
 
 GCS_BUCKET = os.getenv("GCS_EXPORT_BUCKET", "ela-dp-export")
 ACTIVITIES_LIMIT = int(os.getenv("ACTIVITIES_LIMIT", "5"))
@@ -45,6 +46,7 @@ def export_spotify(bucket: str, dry_run: bool = False) -> list[str]:
     Export Spotify-related data.
     - homepage.json
     - music_classement_{period}.json (all periods)
+    - artist_focus_index.json + artist_focus_{id}.json (all artists)
     """
     print("=" * 50)
     print("SPOTIFY EXPORT")
@@ -53,15 +55,20 @@ def export_spotify(bucket: str, dry_run: bool = False) -> list[str]:
     uris = []
 
     # Homepage
-    print("\n[1/2] Exporting homepage...")
+    print("\n[1/3] Exporting homepage...")
     uri = export_homepage(bucket_name=bucket, dry_run=dry_run)
     if uri != "dry-run":
         uris.append(uri)
 
     # Music classement
-    print("\n[2/2] Exporting music classement...")
+    print("\n[2/3] Exporting music classement...")
     music_uris = export_music_classement(bucket_name=bucket, dry_run=dry_run)
     uris.extend(music_uris)
+
+    # Artist focus profiles
+    print("\n[3/3] Exporting artist focus profiles...")
+    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run)
+    uris.extend(artist_uris)
 
     return uris
 

--- a/src/connectors/exporter/all.py
+++ b/src/connectors/exporter/all.py
@@ -66,8 +66,8 @@ def export_spotify(bucket: str, dry_run: bool = False) -> list[str]:
     uris.extend(music_uris)
 
     # Artist focus profiles
-    print("\n[3/3] Exporting artist focus profiles (top 50)...")
-    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run, limit=50)
+    print("\n[3/3] Exporting artist focus profiles (top 50 + active last 24h)...")
+    artist_uris = export_artist_focus(bucket_name=bucket, dry_run=dry_run, top_n=50)
     uris.extend(artist_uris)
 
     return uris

--- a/src/connectors/exporter/artist_focus.py
+++ b/src/connectors/exporter/artist_focus.py
@@ -35,20 +35,10 @@ def query_to_list(client: bigquery.Client, query: str) -> list[dict]:
     return [dict(row) for row in client.query(query).result()]
 
 
-def fetch_overview(client: bigquery.Client, top_n: int = 50) -> list[dict]:
+def fetch_overview(client: bigquery.Client) -> list[dict]:
     return query_to_list(
         client,
-        f"""
-        WITH ranked AS (
-            SELECT *, ROW_NUMBER() OVER (ORDER BY total_plays DESC) AS rn
-            FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview`
-        )
-        SELECT * EXCEPT(rn)
-        FROM ranked
-        WHERE rn <= {top_n}
-           OR CAST(last_heard AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
-        ORDER BY total_plays DESC
-        """,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview` ORDER BY total_plays DESC",
     )
 
 
@@ -108,7 +98,6 @@ def upload_to_gcs(data: dict, bucket_name: str, blob_name: str) -> str:
 def export_artist_focus(
     bucket_name: str | None = None,
     dry_run: bool = False,
-    top_n: int = 50,
 ) -> list[str]:
     """
     Export focus-artist data to GCS.
@@ -126,8 +115,8 @@ def export_artist_focus(
     bucket = bucket_name or GCS_BUCKET
     client = get_bq_client()
 
-    print(f"  Fetching overview (top {top_n} + active last 24h)...")
-    overview_rows = fetch_overview(client, top_n=top_n)
+    print("  Fetching overview...")
+    overview_rows = fetch_overview(client)
     print(f"    → {len(overview_rows)} artists")
 
     print("  Fetching top_tracks...")
@@ -232,10 +221,9 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Export artist focus data to GCS")
     parser.add_argument("--bucket", help="GCS bucket name", default=None)
-    parser.add_argument("--top-n", type=int, default=50, help="Top N artists by total plays (default: 50)")
     parser.add_argument(
         "--dry-run", action="store_true", help="Print JSON instead of uploading"
     )
 
     args = parser.parse_args()
-    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run, top_n=args.top_n)
+    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run)

--- a/src/connectors/exporter/artist_focus.py
+++ b/src/connectors/exporter/artist_focus.py
@@ -35,10 +35,20 @@ def query_to_list(client: bigquery.Client, query: str) -> list[dict]:
     return [dict(row) for row in client.query(query).result()]
 
 
-def fetch_overview(client: bigquery.Client, limit: int = 50) -> list[dict]:
+def fetch_overview(client: bigquery.Client, top_n: int = 50) -> list[dict]:
     return query_to_list(
         client,
-        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview` ORDER BY total_plays DESC LIMIT {limit}",
+        f"""
+        WITH ranked AS (
+            SELECT *, ROW_NUMBER() OVER (ORDER BY total_plays DESC) AS rn
+            FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview`
+        )
+        SELECT * EXCEPT(rn)
+        FROM ranked
+        WHERE rn <= {top_n}
+           OR CAST(last_heard AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+        ORDER BY total_plays DESC
+        """,
     )
 
 
@@ -98,7 +108,7 @@ def upload_to_gcs(data: dict, bucket_name: str, blob_name: str) -> str:
 def export_artist_focus(
     bucket_name: str | None = None,
     dry_run: bool = False,
-    limit: int = 50,
+    top_n: int = 50,
 ) -> list[str]:
     """
     Export focus-artist data to GCS.
@@ -116,8 +126,8 @@ def export_artist_focus(
     bucket = bucket_name or GCS_BUCKET
     client = get_bq_client()
 
-    print(f"  Fetching overview (top {limit})...")
-    overview_rows = fetch_overview(client, limit=limit)
+    print(f"  Fetching overview (top {top_n} + active last 24h)...")
+    overview_rows = fetch_overview(client, top_n=top_n)
     print(f"    → {len(overview_rows)} artists")
 
     print("  Fetching top_tracks...")
@@ -222,10 +232,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Export artist focus data to GCS")
     parser.add_argument("--bucket", help="GCS bucket name", default=None)
-    parser.add_argument("--limit", type=int, default=50, help="Max number of artists to export (default: 50)")
+    parser.add_argument("--top-n", type=int, default=50, help="Top N artists by total plays (default: 50)")
     parser.add_argument(
         "--dry-run", action="store_true", help="Print JSON instead of uploading"
     )
 
     args = parser.parse_args()
-    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run, limit=args.limit)
+    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run, top_n=args.top_n)

--- a/src/connectors/exporter/artist_focus.py
+++ b/src/connectors/exporter/artist_focus.py
@@ -175,7 +175,7 @@ def export_artist_focus(
                 calendar_by_artist, heatmap_by_artist,
                 evolution_by_artist, generated_at,
             )
-            print(f"\n--- DRY RUN: artist_focus_{sample_id}.json ---")
+            print(f"\n--- DRY RUN: artist_focus/{sample_id}.json ---")
             print(json.dumps(sample, default=json_serializer, ensure_ascii=False, indent=2)[:1000])
             print("... (truncated)")
         return []
@@ -183,7 +183,7 @@ def export_artist_focus(
     uris = []
 
     # Upload index
-    blob_name = "artist_focus_index.json"
+    blob_name = "artist_focus/index.json"
     print(f"\n  Uploading {blob_name}...")
     uris.append(upload_to_gcs(index, bucket, blob_name))
 
@@ -197,12 +197,12 @@ def export_artist_focus(
             calendar_by_artist, heatmap_by_artist,
             evolution_by_artist, generated_at,
         )
-        blob_name = f"artist_focus_{artist_id}.json"
+        blob_name = f"artist_focus/{artist_id}.json"
         uri = upload_to_gcs(payload, bucket, blob_name)
         uris.append(uri)
         print(f"    {artist_name} → {uri}")
 
-    print(f"\n  Exported {len(uris)} files to gs://{bucket}/")
+    print(f"\n  Exported {len(uris)} files to gs://{bucket}/artist_focus/")
     return uris
 
 

--- a/src/connectors/exporter/artist_focus.py
+++ b/src/connectors/exporter/artist_focus.py
@@ -35,10 +35,20 @@ def query_to_list(client: bigquery.Client, query: str) -> list[dict]:
     return [dict(row) for row in client.query(query).result()]
 
 
-def fetch_overview(client: bigquery.Client) -> list[dict]:
+def fetch_overview(client: bigquery.Client, top_n: int = 50) -> list[dict]:
     return query_to_list(
         client,
-        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview` ORDER BY total_plays DESC",
+        f"""
+        WITH ranked AS (
+            SELECT *, ROW_NUMBER() OVER (ORDER BY total_plays DESC) AS rn
+            FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview`
+        )
+        SELECT * EXCEPT(rn)
+        FROM ranked
+        WHERE rn <= {top_n}
+           OR CAST(last_heard AS DATE) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+        ORDER BY total_plays DESC
+        """,
     )
 
 
@@ -98,6 +108,7 @@ def upload_to_gcs(data: dict, bucket_name: str, blob_name: str) -> str:
 def export_artist_focus(
     bucket_name: str | None = None,
     dry_run: bool = False,
+    top_n: int = 50,
 ) -> list[str]:
     """
     Export focus-artist data to GCS.
@@ -115,8 +126,8 @@ def export_artist_focus(
     bucket = bucket_name or GCS_BUCKET
     client = get_bq_client()
 
-    print("  Fetching overview...")
-    overview_rows = fetch_overview(client)
+    print(f"  Fetching overview (top {top_n} + active last 24h)...")
+    overview_rows = fetch_overview(client, top_n=top_n)
     print(f"    → {len(overview_rows)} artists")
 
     print("  Fetching top_tracks...")
@@ -221,9 +232,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Export artist focus data to GCS")
     parser.add_argument("--bucket", help="GCS bucket name", default=None)
+    parser.add_argument("--top-n", type=int, default=50, help="Top N artists by total plays (default: 50)")
     parser.add_argument(
         "--dry-run", action="store_true", help="Print JSON instead of uploading"
     )
 
     args = parser.parse_args()
-    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run)
+    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run, top_n=args.top_n)

--- a/src/connectors/exporter/artist_focus.py
+++ b/src/connectors/exporter/artist_focus.py
@@ -1,0 +1,229 @@
+"""
+Export artist focus data from BigQuery to GCS as JSON.
+Generates:
+  - artist_focus_index.json              → liste de tous les artistes (autocomplete)
+  - artist_focus_{artist_id}.json        → profil complet par artiste
+"""
+
+import json
+import os
+from collections import defaultdict
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from google.cloud import bigquery, storage
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT", "polar-scene-465223-f7")
+DATASET = "dp_product_dev"
+GCS_BUCKET = os.getenv("GCS_EXPORT_BUCKET", "ela-dp-export")
+
+
+def json_serializer(obj):
+    """Custom JSON serializer for types not serializable by default."""
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return float(obj)
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+
+def get_bq_client():
+    return bigquery.Client(project=PROJECT_ID)
+
+
+def query_to_list(client: bigquery.Client, query: str) -> list[dict]:
+    return [dict(row) for row in client.query(query).result()]
+
+
+def fetch_overview(client: bigquery.Client) -> list[dict]:
+    return query_to_list(
+        client,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview` ORDER BY total_plays DESC",
+    )
+
+
+def fetch_top_tracks(client: bigquery.Client) -> list[dict]:
+    return query_to_list(
+        client,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__top_tracks` ORDER BY artist_id, track_rank ASC",
+    )
+
+
+def fetch_albums(client: bigquery.Client) -> list[dict]:
+    return query_to_list(
+        client,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__albums` ORDER BY artist_id, total_duration_ms DESC",
+    )
+
+
+def fetch_calendar(client: bigquery.Client) -> list[dict]:
+    return query_to_list(
+        client,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__listening_calendar` ORDER BY artist_id, listen_date ASC",
+    )
+
+
+def fetch_heatmap(client: bigquery.Client) -> list[dict]:
+    return query_to_list(
+        client,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__listening_heatmap` ORDER BY artist_id, day_of_week, hour_of_day ASC",
+    )
+
+
+def fetch_evolution(client: bigquery.Client) -> list[dict]:
+    return query_to_list(
+        client,
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__evolution` ORDER BY artist_id, year_month ASC",
+    )
+
+
+def group_by_artist(rows: list[dict]) -> dict[str, list[dict]]:
+    """Group a flat list of rows into a dict keyed by artist_id."""
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for row in rows:
+        grouped[row["artist_id"]].append(row)
+    return grouped
+
+
+def upload_to_gcs(data: dict, bucket_name: str, blob_name: str) -> str:
+    client = storage.Client(project=PROJECT_ID)
+    blob = client.bucket(bucket_name).blob(blob_name)
+    blob.upload_from_string(
+        json.dumps(data, default=json_serializer, ensure_ascii=False, indent=2),
+        content_type="application/json",
+    )
+    return f"gs://{bucket_name}/{blob_name}"
+
+
+def export_artist_focus(
+    bucket_name: str | None = None,
+    dry_run: bool = False,
+) -> list[str]:
+    """
+    Export focus-artist data to GCS.
+
+    Fetches all 6 product tables in bulk (one query per table), groups rows
+    by artist_id in Python, then writes one JSON file per artist plus an index.
+
+    Args:
+        bucket_name: GCS bucket (defaults to GCS_EXPORT_BUCKET env var)
+        dry_run:     Print summary instead of uploading
+
+    Returns:
+        List of GCS URIs written
+    """
+    bucket = bucket_name or GCS_BUCKET
+    client = get_bq_client()
+
+    print("  Fetching overview...")
+    overview_rows = fetch_overview(client)
+    print(f"    → {len(overview_rows)} artists")
+
+    print("  Fetching top_tracks...")
+    tracks_by_artist = group_by_artist(fetch_top_tracks(client))
+
+    print("  Fetching albums...")
+    albums_by_artist = group_by_artist(fetch_albums(client))
+
+    print("  Fetching listening_calendar...")
+    calendar_by_artist = group_by_artist(fetch_calendar(client))
+
+    print("  Fetching listening_heatmap...")
+    heatmap_by_artist = group_by_artist(fetch_heatmap(client))
+
+    print("  Fetching evolution...")
+    evolution_by_artist = group_by_artist(fetch_evolution(client))
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+
+    # Build index (lightweight: id + name + image + global stats)
+    index = {
+        "artists": [
+            {
+                "artist_id": r["artist_id"],
+                "artist_name": r["artist_name"],
+                "image_url": r.get("image_url"),
+                "total_plays": r["total_plays"],
+                "total_duration": r["total_duration"],
+                "current_streak": r["current_streak"],
+            }
+            for r in overview_rows
+        ],
+        "_generated_at": generated_at,
+    }
+
+    if dry_run:
+        print(f"\n--- DRY RUN: artist_focus_index.json ({len(overview_rows)} artists) ---")
+        print(json.dumps(index, default=json_serializer, ensure_ascii=False, indent=2)[:1000])
+        print("... (truncated)")
+        if overview_rows:
+            sample_id = overview_rows[0]["artist_id"]
+            sample = _build_artist_payload(
+                sample_id, overview_rows[0],
+                tracks_by_artist, albums_by_artist,
+                calendar_by_artist, heatmap_by_artist,
+                evolution_by_artist, generated_at,
+            )
+            print(f"\n--- DRY RUN: artist_focus_{sample_id}.json ---")
+            print(json.dumps(sample, default=json_serializer, ensure_ascii=False, indent=2)[:1000])
+            print("... (truncated)")
+        return []
+
+    uris = []
+
+    # Upload index
+    blob_name = "artist_focus_index.json"
+    print(f"\n  Uploading {blob_name}...")
+    uris.append(upload_to_gcs(index, bucket, blob_name))
+
+    # Upload one file per artist
+    for overview in overview_rows:
+        artist_id = overview["artist_id"]
+        artist_name = overview["artist_name"]
+        payload = _build_artist_payload(
+            artist_id, overview,
+            tracks_by_artist, albums_by_artist,
+            calendar_by_artist, heatmap_by_artist,
+            evolution_by_artist, generated_at,
+        )
+        blob_name = f"artist_focus_{artist_id}.json"
+        uri = upload_to_gcs(payload, bucket, blob_name)
+        uris.append(uri)
+        print(f"    {artist_name} → {uri}")
+
+    print(f"\n  Exported {len(uris)} files to gs://{bucket}/")
+    return uris
+
+
+def _build_artist_payload(
+    artist_id: str,
+    overview: dict,
+    tracks_by_artist: dict,
+    albums_by_artist: dict,
+    calendar_by_artist: dict,
+    heatmap_by_artist: dict,
+    evolution_by_artist: dict,
+    generated_at: str,
+) -> dict:
+    return {
+        "overview": overview,
+        "top_tracks": tracks_by_artist.get(artist_id, []),
+        "albums": albums_by_artist.get(artist_id, []),
+        "calendar": calendar_by_artist.get(artist_id, []),
+        "heatmap": heatmap_by_artist.get(artist_id, []),
+        "evolution": evolution_by_artist.get(artist_id, []),
+        "_generated_at": generated_at,
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Export artist focus data to GCS")
+    parser.add_argument("--bucket", help="GCS bucket name", default=None)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print JSON instead of uploading"
+    )
+
+    args = parser.parse_args()
+    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run)

--- a/src/connectors/exporter/artist_focus.py
+++ b/src/connectors/exporter/artist_focus.py
@@ -35,10 +35,10 @@ def query_to_list(client: bigquery.Client, query: str) -> list[dict]:
     return [dict(row) for row in client.query(query).result()]
 
 
-def fetch_overview(client: bigquery.Client) -> list[dict]:
+def fetch_overview(client: bigquery.Client, limit: int = 50) -> list[dict]:
     return query_to_list(
         client,
-        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview` ORDER BY total_plays DESC",
+        f"SELECT * FROM `{PROJECT_ID}.{DATASET}.pct_focus_artist__overview` ORDER BY total_plays DESC LIMIT {limit}",
     )
 
 
@@ -98,6 +98,7 @@ def upload_to_gcs(data: dict, bucket_name: str, blob_name: str) -> str:
 def export_artist_focus(
     bucket_name: str | None = None,
     dry_run: bool = False,
+    limit: int = 50,
 ) -> list[str]:
     """
     Export focus-artist data to GCS.
@@ -115,8 +116,8 @@ def export_artist_focus(
     bucket = bucket_name or GCS_BUCKET
     client = get_bq_client()
 
-    print("  Fetching overview...")
-    overview_rows = fetch_overview(client)
+    print(f"  Fetching overview (top {limit})...")
+    overview_rows = fetch_overview(client, limit=limit)
     print(f"    → {len(overview_rows)} artists")
 
     print("  Fetching top_tracks...")
@@ -221,9 +222,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Export artist focus data to GCS")
     parser.add_argument("--bucket", help="GCS bucket name", default=None)
+    parser.add_argument("--limit", type=int, default=50, help="Max number of artists to export (default: 50)")
     parser.add_argument(
         "--dry-run", action="store_true", help="Print JSON instead of uploading"
     )
 
     args = parser.parse_args()
-    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run)
+    export_artist_focus(bucket_name=args.bucket, dry_run=args.dry_run, limit=args.limit)

--- a/src/dbt_dataplatform/dbt_project.yml
+++ b/src/dbt_dataplatform/dbt_project.yml
@@ -38,3 +38,6 @@ models:
       music:
         +schema: product_{{ target.name }}
         +materialized: view
+      focus_artist:
+        +schema: product_{{ target.name }}
+        +materialized: view

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__albums.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__albums.sql
@@ -1,0 +1,48 @@
+{{ config(materialized='table', tags=['spotify', 'product']) }}
+
+WITH album_plays AS (
+    SELECT
+        bridge.artistid,
+        tracks.albumid,
+        COUNT(DISTINCT fact.trackid)    AS tracks_heard,
+        COUNT(DISTINCT fact.playedat)   AS total_plays,
+        SUM(tracks.trackdurationms)     AS total_duration_ms,
+        MIN(fact.playedat)              AS first_played_at,
+        MAX(fact.playedat)              AS last_played_at
+    FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+    INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+        ON fact.trackid = bridge.trackid
+    INNER JOIN {{ ref('hub_music__svc_dim_tracks') }} AS tracks
+        ON fact.trackid = tracks.trackid
+    WHERE bridge.artist_role = 'primary'
+      AND bridge.artistid IS NOT NULL
+    GROUP BY bridge.artistid, tracks.albumid
+)
+
+SELECT
+    ap.artistid                                                                         AS artist_id,
+    ap.albumid                                                                          AS album_id,
+    alb.albumname                                                                       AS album_name,
+    alb.albumimageurl                                                                   AS album_image_url,
+    alb.albumexternalurl                                                                AS album_url,
+    alb.album_type,
+    CAST(alb.albumreleasedate AS STRING)                                                AS release_date,
+    alb.albumtotaltracks                                                                AS total_tracks,
+    alb.all_artist_names                                                                AS artist_names,
+    ap.tracks_heard,
+    ap.total_plays,
+    {{ ms_to_hms('ap.total_duration_ms') }}                                            AS total_duration,
+    ap.total_duration_ms,
+    CAST(ap.first_played_at AS STRING)                                                  AS first_played_at,
+    CAST(ap.last_played_at AS STRING)                                                   AS last_played_at,
+    ROUND(100.0 * ap.tracks_heard / NULLIF(alb.albumtotaltracks, 0), 1)               AS completion_rate,
+    CASE
+        WHEN ROUND(100.0 * ap.tracks_heard / NULLIF(alb.albumtotaltracks, 0), 1) >= 90
+            THEN 'complete'
+        WHEN ROUND(100.0 * ap.tracks_heard / NULLIF(alb.albumtotaltracks, 0), 1) >= 50
+            THEN 'partial'
+        ELSE 'shallow'
+    END                                                                                 AS listen_depth
+FROM album_plays AS ap
+INNER JOIN {{ ref('hub_music__svc_dim_albums') }} AS alb ON ap.albumid = alb.albumid
+ORDER BY ap.artistid, ap.total_duration_ms DESC

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__evolution.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__evolution.sql
@@ -1,0 +1,28 @@
+{{ config(materialized='table', tags=['spotify', 'product']) }}
+
+WITH monthly_stats AS (
+    SELECT
+        bridge.artistid,
+        FORMAT_DATE('%Y-%m', DATE(fact.playedat))   AS year_month,
+        COUNT(DISTINCT fact.playedat)               AS play_count,
+        COUNT(DISTINCT fact.trackid)                AS unique_tracks,
+        SUM(tracks.trackdurationms)                 AS total_duration_ms
+    FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+    INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+        ON fact.trackid = bridge.trackid
+    INNER JOIN {{ ref('hub_music__svc_dim_tracks') }} AS tracks
+        ON fact.trackid = tracks.trackid
+    WHERE bridge.artist_role = 'primary'
+      AND bridge.artistid IS NOT NULL
+    GROUP BY bridge.artistid, FORMAT_DATE('%Y-%m', DATE(fact.playedat))
+)
+
+SELECT
+    artistid                                    AS artist_id,
+    year_month,
+    play_count,
+    unique_tracks,
+    total_duration_ms,
+    {{ ms_to_hm('total_duration_ms') }}         AS total_duration
+FROM monthly_stats
+ORDER BY artist_id, year_month

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__listening_calendar.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__listening_calendar.sql
@@ -1,0 +1,26 @@
+{{ config(materialized='table', tags=['spotify', 'product']) }}
+
+WITH daily_stats AS (
+    SELECT
+        bridge.artistid,
+        DATE(fact.playedat)             AS listen_date,
+        COUNT(DISTINCT fact.playedat)   AS play_count,
+        SUM(tracks.trackdurationms)     AS total_duration_ms
+    FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+    INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+        ON fact.trackid = bridge.trackid
+    INNER JOIN {{ ref('hub_music__svc_dim_tracks') }} AS tracks
+        ON fact.trackid = tracks.trackid
+    WHERE bridge.artist_role = 'primary'
+      AND bridge.artistid IS NOT NULL
+    GROUP BY bridge.artistid, DATE(fact.playedat)
+)
+
+SELECT
+    artistid                                        AS artist_id,
+    CAST(listen_date AS STRING)                     AS listen_date,
+    play_count,
+    total_duration_ms,
+    {{ ms_to_hm('total_duration_ms') }}             AS total_duration
+FROM daily_stats
+ORDER BY artist_id, listen_date

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__listening_heatmap.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__listening_heatmap.sql
@@ -1,0 +1,22 @@
+{{ config(materialized='table', tags=['spotify', 'product']) }}
+
+SELECT
+    bridge.artistid                             AS artist_id,
+    EXTRACT(HOUR FROM fact.playedat)            AS hour_of_day,
+    EXTRACT(DAYOFWEEK FROM fact.playedat)       AS day_of_week,
+    FORMAT_TIMESTAMP('%A', fact.playedat)       AS day_name,
+    COUNT(DISTINCT fact.playedat)               AS play_count,
+    SUM(tracks.trackdurationms)                 AS total_duration_ms
+FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+    ON fact.trackid = bridge.trackid
+INNER JOIN {{ ref('hub_music__svc_dim_tracks') }} AS tracks
+    ON fact.trackid = tracks.trackid
+WHERE bridge.artist_role = 'primary'
+  AND bridge.artistid IS NOT NULL
+GROUP BY
+    bridge.artistid,
+    EXTRACT(HOUR FROM fact.playedat),
+    EXTRACT(DAYOFWEEK FROM fact.playedat),
+    FORMAT_TIMESTAMP('%A', fact.playedat)
+ORDER BY artist_id, day_of_week, hour_of_day

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__overview.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__overview.sql
@@ -1,0 +1,48 @@
+{{ config(materialized='table', tags=['spotify', 'product']) }}
+
+WITH listening_stats AS (
+    SELECT
+        bridge.artistid,
+        COUNT(DISTINCT fact.playedat)           AS total_play_count,
+        SUM(tracks.trackdurationms)             AS total_duration_ms,
+        COUNT(DISTINCT fact.trackid)            AS unique_tracks_count,
+        COUNT(DISTINCT tracks.albumid)          AS unique_albums_count,
+        MIN(DATE(fact.playedat))                AS first_played_date,
+        MAX(DATE(fact.playedat))                AS last_played_date,
+        COUNT(DISTINCT DATE(fact.playedat))     AS days_with_listens
+    FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+    INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+        ON fact.trackid = bridge.trackid
+    INNER JOIN {{ ref('hub_music__svc_dim_tracks') }} AS tracks
+        ON fact.trackid = tracks.trackid
+    WHERE bridge.artist_role = 'primary'
+      AND bridge.artistid IS NOT NULL
+    GROUP BY bridge.artistid
+)
+
+SELECT
+    a.artistid                                                                      AS artist_id,
+    a.artistname                                                                    AS artist_name,
+    a.artistexternalurl                                                             AS artist_url,
+    a.imageurllarge                                                                 AS image_url,
+    a.imageurlmedium                                                                AS image_url_medium,
+    a.genres,
+    a.popularity                                                                    AS spotify_popularity,
+    a.followercount                                                                 AS follower_count,
+    s.total_play_count                                                              AS total_plays,
+    {{ ms_to_hms('s.total_duration_ms') }}                                         AS total_duration,
+    s.total_duration_ms,
+    s.unique_tracks_count                                                           AS unique_tracks,
+    s.unique_albums_count                                                           AS unique_albums,
+    CAST(s.first_played_date AS STRING)                                             AS first_heard,
+    CAST(s.last_played_date AS STRING)                                              AS last_heard,
+    s.days_with_listens,
+    DATE_DIFF(CURRENT_DATE(), s.first_played_date, DAY)                            AS days_since_discovery,
+    ROUND(
+        100.0 * s.days_with_listens
+        / NULLIF(DATE_DIFF(CURRENT_DATE(), s.first_played_date, DAY), 0),
+        1
+    )                                                                               AS consistency_score,
+    ROUND(s.total_play_count / NULLIF(s.days_with_listens, 0), 1)                 AS avg_plays_per_active_day
+FROM {{ ref('hub_music__svc_dim_artists') }} AS a
+INNER JOIN listening_stats AS s ON a.artistid = s.artistid

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__overview.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__overview.sql
@@ -1,6 +1,33 @@
 {{ config(materialized='table', tags=['spotify', 'product']) }}
 
-WITH listening_stats AS (
+WITH streak_dates AS (
+    SELECT DISTINCT
+        bridge.artistid,
+        DATE(fact.playedat) AS listen_date
+    FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+    INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+        ON fact.trackid = bridge.trackid
+    WHERE bridge.artist_role = 'primary'
+      AND bridge.artistid IS NOT NULL
+),
+
+numbered AS (
+    SELECT
+        artistid,
+        DATE_DIFF(CURRENT_DATE(), listen_date, DAY) AS days_ago,
+        ROW_NUMBER() OVER (PARTITION BY artistid ORDER BY listen_date DESC) AS rn
+    FROM streak_dates
+    WHERE listen_date <= CURRENT_DATE()
+),
+
+streaks AS (
+    SELECT artistid, COUNT(*) AS current_streak
+    FROM numbered
+    WHERE days_ago = rn - 1   -- jours consécutifs jusqu'à aujourd'hui
+    GROUP BY artistid
+),
+
+listening_stats AS (
     SELECT
         bridge.artistid,
         COUNT(DISTINCT fact.playedat)           AS total_play_count,
@@ -43,6 +70,8 @@ SELECT
         / NULLIF(DATE_DIFF(CURRENT_DATE(), s.first_played_date, DAY), 0),
         1
     )                                                                               AS consistency_score,
-    ROUND(s.total_play_count / NULLIF(s.days_with_listens, 0), 1)                 AS avg_plays_per_active_day
+    ROUND(s.total_play_count / NULLIF(s.days_with_listens, 0), 1)                 AS avg_plays_per_active_day,
+    COALESCE(str.current_streak, 0)                                                AS current_streak
 FROM {{ ref('hub_music__svc_dim_artists') }} AS a
 INNER JOIN listening_stats AS s ON a.artistid = s.artistid
+LEFT JOIN streaks AS str ON a.artistid = str.artistid

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__top_tracks.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__top_tracks.sql
@@ -36,7 +36,7 @@ ranked AS (
     SELECT
         ts.artistid                                                                 AS artist_id,
         ROW_NUMBER() OVER (
-            PARTITION BY ts.artistid ORDER BY ts.play_count DESC
+            PARTITION BY ts.artistid ORDER BY ts.total_listen_ms DESC
         )                                                                           AS track_rank,
         ts.trackid                                                                  AS track_id,
         ts.trackname                                                                AS track_name,

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__top_tracks.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__top_tracks.sql
@@ -48,9 +48,9 @@ ranked AS (
         ts.total_listen_ms                                                          AS total_duration_ms,
         CAST(ts.first_played_at AS STRING)                                          AS first_played_at,
         CAST(ts.last_played_at AS STRING)                                           AS last_played_at,
-        ROUND(100.0 * ts.total_listen_ms / NULLIF(at.artist_total_ms, 0), 1)      AS pct_of_artist_time
+        ROUND(100.0 * ts.total_listen_ms / NULLIF(atot.artist_total_ms, 0), 1)    AS pct_of_artist_time
     FROM track_stats AS ts
-    LEFT JOIN artist_totals AS at ON ts.artistid = at.artistid
+    LEFT JOIN artist_totals AS atot ON ts.artistid = atot.artistid
 )
 
 SELECT *

--- a/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__top_tracks.sql
+++ b/src/dbt_dataplatform/models/product/focus_artist/pct_focus_artist__top_tracks.sql
@@ -1,0 +1,59 @@
+{{ config(materialized='table', tags=['spotify', 'product']) }}
+
+WITH track_stats AS (
+    SELECT
+        bridge.artistid,
+        fact.trackid,
+        tracks.trackname,
+        tracks.trackexternalurl,
+        albums.albumname,
+        albums.albumimageurl,
+        COUNT(DISTINCT fact.playedat)   AS play_count,
+        SUM(tracks.trackdurationms)     AS total_listen_ms,
+        MIN(fact.playedat)              AS first_played_at,
+        MAX(fact.playedat)              AS last_played_at
+    FROM {{ ref('hub_music__svc_fact_played') }} AS fact
+    INNER JOIN {{ ref('hub_music__svc_bridge_tracks_artists') }} AS bridge
+        ON fact.trackid = bridge.trackid
+    INNER JOIN {{ ref('hub_music__svc_dim_tracks') }} AS tracks
+        ON fact.trackid = tracks.trackid
+    LEFT JOIN {{ ref('hub_music__svc_dim_albums') }} AS albums
+        ON tracks.albumid = albums.albumid
+    WHERE bridge.artist_role = 'primary'
+      AND bridge.artistid IS NOT NULL
+    GROUP BY ALL
+),
+
+artist_totals AS (
+    SELECT
+        artistid,
+        SUM(total_listen_ms) AS artist_total_ms
+    FROM track_stats
+    GROUP BY artistid
+),
+
+ranked AS (
+    SELECT
+        ts.artistid                                                                 AS artist_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY ts.artistid ORDER BY ts.play_count DESC
+        )                                                                           AS track_rank,
+        ts.trackid                                                                  AS track_id,
+        ts.trackname                                                                AS track_name,
+        ts.albumname                                                                AS album_name,
+        ts.albumimageurl                                                            AS album_image_url,
+        ts.trackexternalurl                                                         AS track_url,
+        ts.play_count,
+        {{ ms_to_hms('ts.total_listen_ms') }}                                      AS total_duration,
+        ts.total_listen_ms                                                          AS total_duration_ms,
+        CAST(ts.first_played_at AS STRING)                                          AS first_played_at,
+        CAST(ts.last_played_at AS STRING)                                           AS last_played_at,
+        ROUND(100.0 * ts.total_listen_ms / NULLIF(at.artist_total_ms, 0), 1)      AS pct_of_artist_time
+    FROM track_stats AS ts
+    LEFT JOIN artist_totals AS at ON ts.artistid = at.artistid
+)
+
+SELECT *
+FROM ranked
+WHERE track_rank <= 20
+ORDER BY artist_id, track_rank


### PR DESCRIPTION
Creates a dedicated artist focus page with full listening analytics:

dbt (src/dbt_dataplatform/models/product/focus_artist/):
- pct_focus_artist__overview       → global stats card (plays, duration, consistency score, discovery date)
- pct_focus_artist__top_tracks     → top 20 tracks ranked by play count with % of artist time
- pct_focus_artist__albums         → album coverage with completion rate (complete/partial/shallow)
- pct_focus_artist__listening_calendar → daily play heatmap (GitHub-style calendar)
- pct_focus_artist__listening_heatmap  → hour × day-of-week density grid
- pct_focus_artist__evolution      → monthly listening trend

API:
- api/models/artist_focus.py       → Pydantic response models
- api/routers/artist_focus.py      → 8 endpoints under /api/artist-focus/
  GET /artists                     → searchable artist list
  GET /{id}                        → full profile (6 queries via asyncio.gather)
  GET /{id}/overview|tracks|albums|calendar|heatmap|evolution
- api/main.py                      → registers new router

https://claude.ai/code/session_014Da5CxHpta9o7gb8qWMeVT